### PR TITLE
some cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.deps/*
+.libs/*
+*.lo
+*.o
+.dirstamp
+Makefile-bsdiff.am.inc
+AUTHORS
+NEWS
+README
+ChangeLog
+COPYING

--- a/Makefile-bsdiff.am
+++ b/Makefile-bsdiff.am
@@ -1,0 +1,32 @@
+# Copyright (C) 2015 Giuseppe Scrivano <gscrivan@redhat.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions 
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+EXTRA_DIST += $(libbsdiff_srcpath)/bsdiff.h $(libbsdiff_srcpath)/bspatch.h $(libbsdiff_srcpath)/LICENSE $(libbsdiff_srcpath)/README.md
+
+libbsdiff_la_SOURCES = \
+	$(libbsdiff_srcpath)/bsdiff.c \
+	$(libbsdiff_srcpath)/bspatch.c \
+	$(NULL)
+
+libbsdiff_la_CFLAGS = $(AM_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,11 @@
+bin_PROGRAMS = bsdiff bspatch
+
+bsdiff_SOURCES = bsdiff.c
+
+bspatch_SOURCES = bspatch.c
+
+bsdiff_CFLAGS = -DBSDIFF_EXECUTABLE
+bspatch_CFLAGS = -DBSPATCH_EXECUTABLE
+
+EXTRA_DIST = bsdiff.h bspatch.h
+

--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ The overarching goal was to modify the original bsdiff/bspatch code from Colin
 and eliminate external dependencies and provide a simple interface to the core
 functionality.
 
-You can define `BSDIFF_HEADER_ONLY` or `BSPATCH_HEADER_ONLY` to only include
-the header parts of the file. If including a `.c` file makes you feel really
-dirty you can copy paste the header portion at the top of the file into your own
-`.h` file.
-
 I've exposed relevant functions via the `_stream` classes. The only external
 dependency not exposed is `memcmp` in `bsdiff`.
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+touch AUTHORS NEWS README ChangeLog
+cp LICENSE COPYING
+
+autoreconf -fis

--- a/bsdiff.c
+++ b/bsdiff.c
@@ -25,24 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stddef.h>
-#include <stdint.h>
-
-struct bsdiff_stream
-{
-	void* opaque;
-
-	void* (*malloc)(size_t size);
-	void (*free)(void* ptr);
-	int (*write)(struct bsdiff_stream* stream, const void* buffer, int size);
-};
-
-int bsdiff(const uint8_t* old, int64_t oldsize, const uint8_t* new, int64_t newsize, struct bsdiff_stream* stream);
-
-#if !defined(BSDIFF_HEADER_ONLY)
-
-#include <limits.h>
-#include <string.h>
+#include "bsdiff.h"
 
 #define MIN(x,y) (((x)<(y)) ? (x) : (y))
 
@@ -455,7 +438,5 @@ int main(int argc,char *argv[])
 
 	return 0;
 }
-
-#endif
 
 #endif

--- a/bsdiff.c
+++ b/bsdiff.c
@@ -27,6 +27,9 @@
 
 #include "bsdiff.h"
 
+#include <limits.h>
+#include <string.h>
+
 #define MIN(x,y) (((x)<(y)) ? (x) : (y))
 
 static void split(int64_t *I,int64_t *V,int64_t start,int64_t len,int64_t h)

--- a/bsdiff.h
+++ b/bsdiff.h
@@ -1,0 +1,45 @@
+/*-
+ * Copyright 2003-2005 Colin Percival
+ * Copyright 2012 Matthew Endsley
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted providing that the following conditions 
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BSDIFF_H
+# define BSDIFF_H
+
+# include <stddef.h>
+# include <stdint.h>
+
+struct bsdiff_stream
+{
+	void* opaque;
+
+	void* (*malloc)(size_t size);
+	void (*free)(void* ptr);
+	int (*write)(struct bsdiff_stream* stream, const void* buffer, int size);
+};
+
+int bsdiff(const uint8_t* old, int64_t oldsize, const uint8_t* new, int64_t newsize, struct bsdiff_stream* stream);
+
+#endif

--- a/bspatch.c
+++ b/bspatch.c
@@ -25,17 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdint.h>
-
-struct bspatch_stream
-{
-	void* opaque;
-	int (*read)(const struct bspatch_stream* stream, void* buffer, int length);
-};
-
-int bspatch(const uint8_t* old, int64_t oldsize, uint8_t* new, int64_t newsize, struct bspatch_stream* stream);
-
-#if !defined(BSPATCH_HEADER_ONLY)
+#include "bspatch.h"
 
 static int64_t offtin(uint8_t *buf)
 {
@@ -194,5 +184,4 @@ int main(int argc,char * argv[])
 	return 0;
 }
 
-#endif
 #endif

--- a/bspatch.h
+++ b/bspatch.h
@@ -1,0 +1,42 @@
+/*-
+ * Copyright 2003-2005 Colin Percival
+ * Copyright 2012 Matthew Endsley
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted providing that the following conditions 
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef BSPATCH_H
+# define BSPATCH_H
+
+# include <stdint.h>
+
+struct bspatch_stream
+{
+	void* opaque;
+	int (*read)(const struct bspatch_stream* stream, void* buffer, int length);
+};
+
+int bspatch(const uint8_t* old, int64_t oldsize, uint8_t* new, int64_t newsize, struct bspatch_stream* stream);
+
+#endif
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,30 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.69])
+AC_INIT([bsdiff], [0.1])
+AC_CONFIG_SRCDIR([bsdiff.c])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([1.9])
+
+# Checks for programs.
+AC_PROG_CC
+
+# Checks for libraries.
+# FIXME: Replace `main' with a function in `-lbz2':
+AC_CHECK_LIB([bz2], [BZ2_bzReadOpen])
+
+AC_CHECK_HEADERS([fcntl.h limits.h stddef.h stdint.h stdlib.h string.h unistd.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_TYPE_INT64_T
+AC_TYPE_OFF_T
+AC_TYPE_SIZE_T
+AC_TYPE_UINT8_T
+
+# Checks for library functions.
+AC_FUNC_MALLOC
+AC_CHECK_FUNCS([memset])
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
it looks quite ugly to #include a .c file.  Split definitions in .h files so it is easier and much cleaner to use the library.