### PR TITLE
Use the same access mode of original file instead of fixed value

### DIFF
--- a/bspatch.c
+++ b/bspatch.c
@@ -102,6 +102,8 @@ int bspatch(const uint8_t* old, int64_t oldsize, uint8_t* new, int64_t newsize, 
 #include <stdio.h>
 #include <string.h>
 #include <err.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
 
@@ -129,6 +131,7 @@ int main(int argc,char * argv[])
 	int64_t oldsize, newsize;
 	BZFILE* bz2;
 	struct bspatch_stream stream;
+	struct stat sb;
 
 	if(argc!=4) errx(1,"usage: %s oldfile newfile patchfile\n",argv[0]);
 
@@ -158,6 +161,7 @@ int main(int argc,char * argv[])
 		((old=malloc(oldsize+1))==NULL) ||
 		(lseek(fd,0,SEEK_SET)!=0) ||
 		(read(fd,old,oldsize)!=oldsize) ||
+		(fstat(fd, &sb)) ||
 		(close(fd)==-1)) err(1,"%s",argv[1]);
 	if((new=malloc(newsize+1))==NULL) err(1,NULL);
 
@@ -174,7 +178,7 @@ int main(int argc,char * argv[])
 	fclose(f);
 
 	/* Write the new file */
-	if(((fd=open(argv[2],O_CREAT|O_TRUNC|O_WRONLY,0666))<0) ||
+	if(((fd=open(argv[2],O_CREAT|O_TRUNC|O_WRONLY,sb.st_mode))<0) ||
 		(write(fd,new,newsize)!=newsize) || (close(fd)==-1))
 		err(1,"%s",argv[2]);
 


### PR DESCRIPTION
The created file after running bspatch command always has the fixed access mode since the mode value is fixed as constant number (i.e 0666) in bspatch.c. IMO, it should be the same access mode of the original file. 

This patch uses the same access mode of the original file instead of fixed value. 

~~~
$ bsdiff/bsdiff hello hello2 delta.bsdiff
$ bsdiff/bspatch hello hello_new delta.bsdiff
$ ls -al hello_new hello
-rwxrwxr-x 1 again4you again4you 8551  4월  5 15:06 hello
-rwxrwxr-x 1 again4you again4you 8551  4월  6 18:33 hello_new
~~~