### PR TITLE
fix keyword "new" warning in Cpp & OC

### DIFF
--- a/bsdiff.h
+++ b/bsdiff.h
@@ -40,6 +40,6 @@ struct bsdiff_stream
 	int (*write)(struct bsdiff_stream* stream, const void* buffer, int size);
 };
 
-int bsdiff(const uint8_t* old, int64_t oldsize, const uint8_t* new, int64_t newsize, struct bsdiff_stream* stream);
+int bsdiff(const uint8_t* oldbuffer, int64_t oldsize, const uint8_t* newbuffer, int64_t newsize, struct bsdiff_stream* stream);
 
 #endif

--- a/bspatch.h
+++ b/bspatch.h
@@ -36,7 +36,7 @@ struct bspatch_stream
 	int (*read)(const struct bspatch_stream* stream, void* buffer, int length);
 };
 
-int bspatch(const uint8_t* old, int64_t oldsize, uint8_t* new, int64_t newsize, struct bspatch_stream* stream);
+int bspatch(const uint8_t* oldbuffer, int64_t oldsize, uint8_t* newbuffer, int64_t newsize, struct bspatch_stream* stream);
 
 #endif
 


### PR DESCRIPTION
The keywords "new" is not allowed in some language such as cpp and OC, so fix it!